### PR TITLE
add missing lastInitializedRound

### DIFF
--- a/src/components/BasicNavbar.js
+++ b/src/components/BasicNavbar.js
@@ -112,7 +112,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
 
         <NavbarLinks>
           <Form
-            onSubmit={e => {
+            onSubmit={(e) => {
               e.preventDefault()
               const data = new FormData(e.target)
               history.push(`/accounts/${data.get('address')}`)
@@ -125,7 +125,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
               type="search"
               pattern="^0x[a-fA-F0-9]{40}$"
               placeholder="Enter an ETH account address"
-              onChange={e => {
+              onChange={(e) => {
                 const re = new RegExp(e.target.pattern)
                 const sub = document.getElementById('sub')
                 const invalidColor = '#868686'
@@ -165,7 +165,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
                 const { pathname } = location
                 const [addr] = pathname
                   .split('/')
-                  .filter(x => x.substring(0, 2) === '0x')
+                  .filter((x) => x.substring(0, 2) === '0x')
                 return addr ? addr.toLowerCase() === myAccountAddress : false
               }}
             >
@@ -223,7 +223,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
                 style={{
                   width: '95%',
                 }}
-                onSubmit={e => {
+                onSubmit={(e) => {
                   e.preventDefault()
                   const data = new FormData(e.target)
                   history.push(`/accounts/${data.get('address')}`)
@@ -236,7 +236,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
                   type="search"
                   pattern="^0x[a-fA-F0-9]{40}$"
                   placeholder="Enter an ETH account address"
-                  onChange={e => {
+                  onChange={(e) => {
                     const re = new RegExp(e.target.pattern)
                     const sub = document.getElementById('sub2')
                     const invalidColor = '#868686'
@@ -307,7 +307,7 @@ const NavbarLinks = styled.div`
 `
 
 const NavbarLink = styled(NavLink).attrs({
-  activeStyle: props => ({
+  activeStyle: (props) => ({
     color: 'var(--primary)',
     backgroundImage:
       'linear-gradient(to bottom,rgba(0,0,0,0),rgba(0,0,0,0) 0px,var(--primary) 0px,var(--primary) 4px,rgba(0,0,0,0) 4px)',

--- a/src/enhancers/index.js
+++ b/src/enhancers/index.js
@@ -24,7 +24,7 @@ type nestFunc = (
  * Creates a component which nests given components from right to left
  */
 export const nest: nestFunc = (A, B, ...rest) => {
-  const C = props => (
+  const C = (props) => (
     <A {...props}>
       <B />
     </A>
@@ -46,9 +46,9 @@ export const cond: condFunc = (() => {
   /**
    * Conditionally renders children if `test` prop is truthy
    */
-  const Cond: CondProps => React.Node = ({ test, children, ...props }) =>
+  const Cond: (CondProps) => React.Node = ({ test, children, ...props }) =>
     !test ? null : React.cloneElement(children, props)
-  return child => nest(Cond, child)
+  return (child) => nest(Cond, child)
 })()
 
 /**
@@ -67,7 +67,7 @@ export const withProp = (key: string, value: any) => (
  * Adds a `paths` object to props
  */
 export const withPathMatches = (matches: { [key: string]: string }) =>
-  mapProps(props => {
+  mapProps((props) => {
     return {
       ...props,
       paths: Object.entries(matches).reduce((paths, [key, path]) => {
@@ -241,7 +241,6 @@ const CurrentRoundQuery = gql`
   fragment RoundFragment on Round {
     id
     initialized
-    lastInitializedRound
     length
     startBlock
   }


### PR DESCRIPTION
An update to the subgraph moved `lastInitializedRound` to the Protocol entity, however the classic explorer still thinks it belongs in the Round entity causing graphql requests to fail. This PR adds `lastInitializedRound` to the Round entity.